### PR TITLE
Improve AppRouter logic

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,21 +1,15 @@
-import 'package:bloc_architecture_app/presentation/router/app_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'logic/debug/app_bloc_observer.dart';
+import 'presentation/router/app_router.dart';
 
 void main() {
   Bloc.observer = AppBlocObserver();
-  runApp(MyApp(
-    appRouter: AppRouter(),
-  ));
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  final AppRouter appRouter;
-
-  const MyApp({Key key, @required this.appRouter}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -25,7 +19,8 @@ class MyApp extends StatelessWidget {
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
       debugShowCheckedModeBanner: false,
-      onGenerateRoute: appRouter.onGenerateRoute,
+      initialRoute: AppRouter.home,
+      onGenerateRoute: AppRouter.onGenerateRoute,
     );
   }
 }

--- a/lib/presentation/router/app_router.dart
+++ b/lib/presentation/router/app_router.dart
@@ -2,17 +2,27 @@ import 'package:bloc_architecture_app/constants/strings.dart';
 import 'package:bloc_architecture_app/presentation/screens/home_screen/home_screen.dart';
 import 'package:flutter/material.dart';
 
+class RouteException implements Exception {
+  final String message;
+
+  const RouteException(this.message);
+}
+
 class AppRouter {
-  Route onGenerateRoute(RouteSettings settings) {
+  static const String home = '/';
+
+  const AppRouter._();
+
+  static Route<dynamic> onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
-      case '/':
+      case home:
         return MaterialPageRoute(
           builder: (_) => HomeScreen(
             title: Strings.homeScreenTitle,
           ),
         );
       default:
-        return null;
+        throw const RouteException('Route not found');
     }
   }
 }


### PR DESCRIPTION
AppRouter logic could be improved:
1) Make `AppRouter.onGenerateRoute` method static so you won't need to create an instance of the `AppRouter` in `main.dart`, the code is a little bit cleaner.
2) Make all the routes as static strings in the `AppRouter` class so you could later use them from UI by calling `Navigator.of(context).pushNamed(AppRouter.routeName)`. This way, you ensure that there won't be undefined route calls. If an undefined route is used, a custom `RouteException` would be thrown so you would be aware that you need to handle it.
3. (Optional) I haven't added it, but I would recommend adding linter to the project as soon as possible (lint, pragmatic, custom `analysis_options.yaml` file, etc.).